### PR TITLE
Net::SSLeay is incompatible with macOS' OpenSSL

### DIFF
--- a/auto-multiple-choice.rb
+++ b/auto-multiple-choice.rb
@@ -36,8 +36,9 @@ class AutoMultipleChoice < Formula
   depends_on "libx11"
   depends_on "netpbm"
   depends_on "opencv" # vendored Pango, stuck at v1.42.4
+  depends_on "openssl@1.1"
   depends_on "perl"
-  depends_on "poppler"
+  depends_on "poppler" # https://github.com/maelvls/homebrew-amc/pull/69
   depends_on "qpdf"
 
   # conflicts_with "auto-multiple-choice-devel", :because => "both install `bin/auto-multiple-choice`"
@@ -712,6 +713,11 @@ class AutoMultipleChoice < Formula
           #
           #  use lib ".";
           inreplace "Makefile.PL", "use inc::Module::Install;", `use lib ".";\nuse inc::Module::Install;`
+          system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}", "INSTALLMAN1DIR=none", "INSTALLMAN3DIR=none"
+          system "make"
+          system "make", "install"
+        elsif package == "Net::SSLeay"
+          ENV["OPENSSL_PREFIX"] = Formula["openssl@1.1"].prefix.to_s
           system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}", "INSTALLMAN1DIR=none", "INSTALLMAN3DIR=none"
           system "make"
           system "make", "install"


### PR DESCRIPTION
I was not able to install Net::SSLeay without using openssl@1.1. What is weird is that previously, Net::SSLeay would work with the system OpenSSL version.

The error is:

```
 *** Found LibreSSL-2.8.3 installed in /usr
 *** Be sure to use the same compiler and options to compile your OpenSSL, perl,
     and Net::SSLeay. Mixing and matching compilers is not supported.
 Checking if your kit is complete...
 Looks good
 WARNING: /usr/local/opt/perl/bin/perl is loading libcrypto in an unsafe way
```

See: https://stackoverflow.com/questions/62943220

Fixes #68.