### PR TITLE
Use gobject-introspection 1.72 to get around segfaults on Apple Silicon

### DIFF
--- a/amc-gobject-introspection.rb
+++ b/amc-gobject-introspection.rb
@@ -1,0 +1,69 @@
+class AmcGobjectIntrospection < Formula
+  include Language::Python::Shebang
+
+  # I had to vendor Gobject-introspection in order to fix segfaults happening on
+  # Apple Silicon due to g_callable_info_prepare_closure. See:
+  # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/301
+  # This vendoring can be removed as soon as gobject-introspection 1.72 is
+  # released and its Homebrew formula is updated.
+
+  desc "Generate introspection data for GObject libraries"
+  homepage "https://gi.readthedocs.io/en/latest/"
+  url "https://github.com/maelvls/gobject-introspection/archive/refs/tags/1.70.0-16-g366a886b.tar.gz"
+  sha256 "6f31219c9c2678d488725ce3dd94e65ef7110ce6191c68d911b09f8b55880856"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later", "MIT"]
+  revision 0
+
+  keg_only "vendored version of Homebrew's gobject-introspection"
+
+  depends_on "bison" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "cairo"
+  depends_on "glib"
+  depends_on "libffi"
+  depends_on "pkg-config"
+  depends_on "python@3.9"
+
+  uses_from_macos "flex" => :build
+
+  resource "tutorial" do
+    url "https://gist.github.com/7a0023656ccfe309337a.git",
+        revision: "499ac89f8a9ad17d250e907f74912159ea216416"
+  end
+
+  # Fix library search path on non-/usr/local installs (e.g. Apple Silicon)
+  # See: https://github.com/Homebrew/homebrew-core/issues/75020
+  #      https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/273
+  patch do
+    url "https://gitlab.gnome.org/tschoonj/gobject-introspection/-/commit/a7be304478b25271166cd92d110f251a8742d16b.diff"
+    sha256 "740c9fba499b1491689b0b1216f9e693e5cb35c9a8565df4314341122ce12f81"
+  end
+
+  def install
+    ENV["GI_SCANNER_DISABLE_CACHE"] = "true"
+    inreplace "giscanner/transformer.py", "/usr/share", "#{HOMEBREW_PREFIX}/share"
+    inreplace "meson.build",
+      "config.set_quoted('GOBJECT_INTROSPECTION_LIBDIR', join_paths(get_option('prefix'), get_option('libdir')))",
+      "config.set_quoted('GOBJECT_INTROSPECTION_LIBDIR', '#{HOMEBREW_PREFIX}/lib')"
+
+    mkdir "build" do
+      system "meson", *std_meson_args,
+        "-Dpython=#{Formula["python@3.9"].opt_bin}/python3",
+        "-Dextra_library_paths=#{HOMEBREW_PREFIX}/lib",
+        ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+      bin.find { |f| rewrite_shebang detected_python_shebang, f }
+    end
+  end
+
+  test do
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libffi"].opt_lib/"pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["amc-gobject-introspection"].opt_lib/"pkgconfig"
+    ENV.prepend_path "PATH", Formula["amc-gobject-introspection"].opt_bin.to_s
+    resource("tutorial").stage testpath
+    system "make"
+    assert_predicate testpath/"Tut-0.1.typelib", :exist?
+  end
+end


### PR DESCRIPTION
Currently, Homebrew and MacPorts rely on gobject-introspection 1.70.0.

The version 1.7.2, yet to be released, includes a fix that prevents segfaults on Apple Silicon hardware: https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/301

I will, for now, apply a patch of mine to Glib::Object::Introspection in order to use gobject-introspection 1.72.0. The patch is stored In a GitHub Gist at https://gist.github.com/maelvls/9a4890e7c5adf2309a453d0cdbffaa19.

After merging this PR, the auto-multiple-choice formula should start working on M1 macs.

Future tasks when this PR is merged: 

- As soon as a new version 1.72 gobject-introspection is released, update the Homebrew formula [`gobject-introspection`](https://formulae.brew.sh/formula/gobject-introspection).
- Open a ticket for [Glib-Object-Introspection](https://rt.cpan.org/Public/Dist/Display.html?Name=Glib-Object-Introspection) with a patch since I don't know where to open a PR.

Fixes #55 