### PR TITLE
update dependancy on openssl@3

### DIFF
--- a/auto-multiple-choice.rb
+++ b/auto-multiple-choice.rb
@@ -37,7 +37,7 @@ class AutoMultipleChoice < Formula
   depends_on "libx11"
   depends_on "netpbm"
   depends_on "opencv" # vendored Pango, stuck at v1.42.4
-  depends_on "openssl@1.1" # required by Net::SSLeay
+  depends_on "openssl@3" # required by Net::SSLeay
   depends_on "perl"
   depends_on "poppler"
   depends_on "qpdf"


### PR DESCRIPTION
Error: openssl@1.1 has been disabled because it is not supported upstream! It was disabled on 2024-10-24.