### PR TITLE
fix: Bump OpenSSL from v1.1 to v3 to resolve upstream deprecation

### DIFF
--- a/auto-multiple-choice.rb
+++ b/auto-multiple-choice.rb
@@ -37,7 +37,7 @@ class AutoMultipleChoice < Formula
   depends_on "libx11"
   depends_on "netpbm"
   depends_on "opencv" # vendored Pango, stuck at v1.42.4
-  depends_on "openssl@1.1" # required by Net::SSLeay
+  depends_on "openssl@3" # required by Net::SSLeay
   depends_on "perl"
   depends_on "poppler"
   depends_on "qpdf"


### PR DESCRIPTION
This PR updates the formula to replace `openssl@1.1` with `openssl@3`, fixing the following error:

```
Error: openssl@1.1 has been disabled because it is not supported upstream!
It was disabled on 2024-10-24.
```

**Changes Made:**

* Replaced `openssl@1.1` with `openssl@3` in the formula/dependency list

**Fixes:**

* Closes [[#94](https://github.com/maelvls/homebrew-amc/issues/94)](https://github.com/maelvls/homebrew-amc/issues/94)

---

**Test Plan:**

* `brew install` works without triggering the OpenSSL deprecation error
* All formula dependencies resolve correctly with OpenSSL v3

---
